### PR TITLE
Fix NPE when running integration tests locally. (#453)

### DIFF
--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
@@ -56,7 +56,7 @@ public class OperatonBpmRunDeploymentConfiguration extends DefaultDeploymentConf
   protected String getNormalizedDeploymentDir() {
     String result = deploymentDir;
 
-    if(File.separator.equals("\\")) {
+    if(result != null && File.separator.equals("\\")) {
       result = result.replace("\\", "/");
     }
     return result;


### PR DESCRIPTION
Added null check for deploymentDir in OperatonBpmRunDeploymentConfiguration#getNormalizedDeploymentDir

A NPE arises if operaton.deploymentDir is null because in OperatonBpmRunDeploymentConfiguration.getNormalizedDeploymentDir the value is accessed without a check. In a regular installation the property is set in the run.bat/run.sh scripts. But these are not used for the integration tests. Instead the default is taken from OperatonBpmRunConfiguration.operatonDeploymentConfiguration. Here the value is configured to be null.