### PR TITLE
Migrate concurrency tests to JUnit 5

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.OptimisticLockingException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -30,7 +30,7 @@ import org.operaton.bpm.engine.impl.errorcode.BuiltinExceptionCode;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.slf4j.Logger;
 
@@ -53,9 +53,9 @@ public abstract class AbstractCompetingTransactionsOptimisticLockingTest {
 
   protected static ControllableThread activeThread;
 
-  protected abstract ProcessEngineTestRule getTestRule();
+  protected abstract ProcessEngineTestExtension getTestRule();
 
-  @After
+  @AfterEach
   public void resetConfiguration() {
     processEngineConfiguration.setEnableOptimisticLockingOnForeignKeyViolation(true);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.errorcode.BuiltinExceptionCode;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -24,7 +24,7 @@ import org.operaton.bpm.engine.test.Deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends ConcurrencyTestCase {
+class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends ConcurrencyTestCase {
 
   protected static class ControllableDeleteProcessDefinitionCommand extends ControllableCommand<Void> {
 
@@ -75,7 +75,7 @@ public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends Concu
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void shouldReturnForeignKeyConstraintErrorCode() {
+  void shouldReturnForeignKeyConstraintErrorCode() {
     // given
     ThreadControl thread1 = executeControllableCommand(new ControllableStartProcessInstanceCommand("oneTaskProcess"));
     thread1.reportInterrupts();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CancelAcquiredJobTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CancelAcquiredJobTest.java
@@ -22,41 +22,36 @@ import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * @author Daniel Meyer
  *
  */
-public class CancelAcquiredJobTest {
+class CancelAcquiredJobTest {
 
-  @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule();
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
-  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
   }
 
   @Deployment
   @Test
-  public void testBothJobsAcquiredAtSameTime() {
+  void testBothJobsAcquiredAtSameTime() {
 
     runtimeService.startProcessInstanceByKey("testProcess");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingActivityInstanceCancellationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingActivityInstanceCancellationTest.java
@@ -23,15 +23,12 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.ActivityInstanceCancellationCmd;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.slf4j.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,23 +38,20 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Roman Smirnov
  *
  */
-public class CompetingActivityInstanceCancellationTest {
+class CompetingActivityInstanceCancellationTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule();
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
-  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
   }
@@ -99,7 +93,7 @@ public class CompetingActivityInstanceCancellationTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingForkTest.testCompetingFork.bpmn20.xml"})
   @Test
-  public void testCompetingCancellation() {
+  void testCompetingCancellation() {
     String processInstanceId = runtimeService.startProcessInstanceByKey("process").getId();
 
     ActivityInstance activityInstance = runtimeService.getActivityInstance(processInstanceId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingByteVariableAccessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingByteVariableAccessTest.java
@@ -26,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * <pre>
@@ -44,10 +44,10 @@ import org.junit.Test;
  *
  * @author Thorben Lindhauer
  */
-public class CompetingByteVariableAccessTest extends ConcurrencyTestCase {
+class CompetingByteVariableAccessTest extends ConcurrencyTestCase {
 
   @Test
-  public void testConcurrentVariableRemoval() {
+  void testConcurrentVariableRemoval() {
    testRule.deploy(createExecutableProcess("test")
         .startEvent()
           .userTask()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingCompleteTaskSetVariableTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingCompleteTaskSetVariableTest.java
@@ -25,13 +25,13 @@ import org.operaton.bpm.engine.impl.cmd.SetTaskVariablesCmd;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Svetlana Dorokhova
  *
  */
-public class CompetingCompleteTaskSetVariableTest extends ConcurrencyTestCase {
+class CompetingCompleteTaskSetVariableTest extends ConcurrencyTestCase {
 
   protected static class ControllableCompleteTaskCommand extends ConcurrencyTestCase.ControllableCommand<Void> {
 
@@ -83,7 +83,7 @@ public class CompetingCompleteTaskSetVariableTest extends ConcurrencyTestCase {
 
   @Deployment
   @Test
-  public void testCompleteTaskSetLocalVariable() {
+  void testCompleteTaskSetLocalVariable() {
     runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     final String taskId = taskService.createTaskQuery().singleResult().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskFetchingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskFetchingTest.java
@@ -30,34 +30,29 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.FetchExternalTasksCmd;
 import org.operaton.bpm.engine.impl.externaltask.TopicFetchInstruction;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * @author Thorben Lindhauer
  *
  */
-public class CompetingExternalTaskFetchingTest {
+class CompetingExternalTaskFetchingTest {
 
-  @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule();
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
-  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
   }
@@ -98,7 +93,7 @@ public class CompetingExternalTaskFetchingTest {
 
   @Deployment
   @Test
-  public void testCompetingExternalTaskFetching() {
+  void testCompetingExternalTaskFetching() {
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
 
     ExternalTaskFetcherThread thread1 = new ExternalTaskFetcherThread("thread1", 5, "externalTaskTopic");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingExternalTaskLockingTest.java
@@ -24,7 +24,7 @@ import org.operaton.bpm.engine.impl.cmd.LockExternalTaskCmd;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test covers the use-case where two competing transactions
@@ -39,15 +39,15 @@ import org.junit.Test;
  * 6. TX2 attempts to flush the result and receives
  *    an OLE since the lock was already updated by TX1.
  */
-public class CompetingExternalTaskLockingTest extends ConcurrencyTestCase {
+class CompetingExternalTaskLockingTest extends ConcurrencyTestCase {
 
   protected static final String WORKER_ID_1 = "WORKER_1";
   protected static final String WORKER_ID_2 = "WORKER_2";
   protected static final long LOCK_DURATION = 10000L;
 
-  @Deployment(resources = { "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml"})
+  @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml"})
   @Test
-  public void shouldThrowOleOnConcurrentLockingAttempt() throws InterruptedException {
+  void shouldThrowOleOnConcurrentLockingAttempt() throws InterruptedException {
     // given
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     String externalTaskId = externalTaskService.createExternalTaskQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingForkTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingForkTest.java
@@ -26,39 +26,34 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.CompleteTaskCmd;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Roman Smirnov
  *
  */
-public class CompetingForkTest {
+class CompetingForkTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule();
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
-  public ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
   protected TaskService taskService;
 
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
@@ -99,7 +94,7 @@ public class CompetingForkTest {
 
   @Deployment
   @Test
-  public void testCompetingFork() {
+  void testCompetingFork() {
     runtimeService.startProcessInstanceByKey("process");
 
     TaskQuery query = taskService.createTaskQuery();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJobAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJobAcquisitionTest.java
@@ -26,12 +26,12 @@ import org.operaton.bpm.engine.impl.cmd.AcquireJobsCmd;
 import org.operaton.bpm.engine.impl.jobexecutor.AcquiredJobs;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 
@@ -51,15 +51,15 @@ import org.slf4j.Logger;
  *
  * @author Tom Baeyens
  */
-public class CompetingJobAcquisitionTest {
+class CompetingJobAcquisitionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
@@ -68,8 +68,8 @@ public class CompetingJobAcquisitionTest {
   protected String databaseType;
 
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     databaseType = processEngineConfiguration.getDatabaseType();
     runtimeService = engineRule.getRuntimeService();
@@ -77,7 +77,7 @@ public class CompetingJobAcquisitionTest {
 
   @Deployment
   @Test
-  public void testCompetingJobAcquisitions() {
+  void testCompetingJobAcquisitions() {
     runtimeService.startProcessInstanceByKey("CompetingJobAcquisitionProcess");
 
     LOG.debug("test thread starts thread one");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJoinTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingJoinTest.java
@@ -26,35 +26,34 @@ import org.operaton.bpm.engine.impl.cmd.SignalCmd;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 
 /**
  * @author Tom Baeyens
  */
-public class CompetingJoinTest {
+class CompetingJoinTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
 
   protected static ControllableThread activeThread;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
   }
@@ -88,7 +87,7 @@ public class CompetingJoinTest {
 
   @Deployment
   @Test
-  public void testCompetingJoins() {
+  void testCompetingJoins() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("CompetingJoinsProcess");
     Execution execution1 = runtimeService
       .createExecutionQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
@@ -38,18 +38,18 @@ import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Thorben Lindhauer
  *
  */
-public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
+class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     ((ProcessEngineConfigurationImpl)processEngine.getProcessEngineConfiguration()).getCommandExecutorTxRequiresNew().execute(commandContext -> {
 
       List<HistoricJobLog> jobLogs = processEngine.getHistoryService().createHistoricJobLogQuery().list();
@@ -66,7 +66,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Test
   @RequiredDatabase(excludes = DbSqlSessionFactory.H2)
-  public void testConcurrentExclusiveCorrelation() throws InterruptedException {
+  void testConcurrentExclusiveCorrelation() throws InterruptedException {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -118,7 +118,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Test
-  public void testConcurrentCorrelationFailsWithOptimisticLockingException() {
+  void testConcurrentCorrelationFailsWithOptimisticLockingException() {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -158,7 +158,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Test
-  public void testConcurrentExclusiveCorrelationToDifferentExecutions() {
+  void testConcurrentExclusiveCorrelationToDifferentExecutions() {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -209,7 +209,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
    */
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Test
-  public void testConcurrentExclusiveCorrelationToDifferentExecutionsCase2() {
+  void testConcurrentExclusiveCorrelationToDifferentExecutionsCase2() {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -255,7 +255,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Test
-  public void testConcurrentMixedCorrelation() {
+  void testConcurrentMixedCorrelation() {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -308,7 +308,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.catchMessageProcess.bpmn20.xml")
   @Ignore("CAM-3636")
   @Test
-  public void testConcurrentMixedCorrelationCase2() throws InterruptedException {
+  void testConcurrentMixedCorrelationCase2() throws InterruptedException {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -358,7 +358,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.eventSubprocess.bpmn")
   @Test
-  public void testEventSubprocess() {
+  void testEventSubprocess() {
     InvocationLogListener.reset();
 
     // given a process instance
@@ -393,7 +393,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment
   @Test
-  public void testConcurrentMessageCorrelationAndTreeCompaction() {
+  void testConcurrentMessageCorrelationAndTreeCompaction() {
     runtimeService.startProcessInstanceByKey("process");
 
     // trigger non-interrupting boundary event and wait before flush
@@ -422,7 +422,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.testConcurrentMessageCorrelationAndTreeCompaction.bpmn20.xml")
   @Test
-  public void testConcurrentTreeCompactionAndMessageCorrelation() {
+  void testConcurrentTreeCompactionAndMessageCorrelation() {
     runtimeService.startProcessInstanceByKey("process");
     List<Task> tasks = taskService.createTaskQuery().list();
 
@@ -447,7 +447,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment
   @Test
-  public void testConcurrentMessageCorrelationTwiceAndTreeCompaction() {
+  void testConcurrentMessageCorrelationTwiceAndTreeCompaction() {
     runtimeService.startProcessInstanceByKey("process");
 
     // trigger non-interrupting boundary event 1 that ends in a none end event immediately
@@ -479,7 +479,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
   @Deployment
   @Test
-  public void testConcurrentEndExecutionListener() {
+  void testConcurrentEndExecutionListener() {
     InvocationLogListener.reset();
 
     // given a process instance

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.java
@@ -28,35 +28,34 @@ import org.operaton.bpm.engine.impl.cmmn.cmd.StateTransitionCaseExecutionCmd;
 import org.operaton.bpm.engine.impl.cmmn.entity.runtime.CaseExecutionEntity;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Roman Smirnov
  *
  */
-public class CompetingParentCompletionTest {
+class CompetingParentCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected CaseService caseService;
 
   protected static ControllableThread activeThread;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     caseService = engineRule.getCaseService();
   }
@@ -127,7 +126,7 @@ public class CompetingParentCompletionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.testComplete.cmmn"})
   @Test
-  public void testComplete() {
+  void testComplete() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()
@@ -168,7 +167,7 @@ public class CompetingParentCompletionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.testDisable.cmmn"})
   @Test
-  public void testDisable() {
+  void testDisable() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()
@@ -209,7 +208,7 @@ public class CompetingParentCompletionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingParentCompletionTest.testTerminate.cmmn"})
   @Test
-  public void testTerminate() {
+  void testTerminate() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingProcessCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingProcessCompletionTest.java
@@ -28,27 +28,26 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.CompleteTaskCmd;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 
 /**
  * @author Tom Baeyens
  */
-public class CompetingProcessCompletionTest {
+class CompetingProcessCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
@@ -56,8 +55,8 @@ public class CompetingProcessCompletionTest {
 
   protected static ControllableThread activeThread;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
@@ -96,7 +95,7 @@ public class CompetingProcessCompletionTest {
    */
   @Deployment
   @Test
-  public void testCompetingEnd() {
+  void testCompetingEnd() {
     runtimeService.startProcessInstanceByKey("CompetingEndProcess");
 
     List<Task> tasks = taskService.createTaskQuery().list();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.java
@@ -27,35 +27,35 @@ import org.operaton.bpm.engine.impl.cmmn.cmd.ManualStartCaseExecutionCmd;
 import org.operaton.bpm.engine.impl.cmmn.cmd.StateTransitionCaseExecutionCmd;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Roman Smirnov
  *
  */
-public class CompetingSentrySatisfactionTest {
+class CompetingSentrySatisfactionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected CaseService caseService;
 
   protected static ControllableThread activeThread;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     caseService = engineRule.getCaseService();
   }
@@ -109,7 +109,7 @@ public class CompetingSentrySatisfactionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.testEntryCriteriaWithAndSentry.cmmn"})
   @Test
-  public void testEntryCriteriaWithAndSentry() {
+  void testEntryCriteriaWithAndSentry() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()
@@ -152,7 +152,7 @@ public class CompetingSentrySatisfactionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.testExitCriteriaWithAndSentry.cmmn"})
   @Test
-  public void testExitCriteriaWithAndSentry() {
+  void testExitCriteriaWithAndSentry() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()
@@ -195,7 +195,7 @@ public class CompetingSentrySatisfactionTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.testEntryCriteriaWithOrSentry.cmmn"})
   @Test
-  public void testEntryCriteriaWithOrSentry() {
+  void testEntryCriteriaWithOrSentry() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()
@@ -237,9 +237,9 @@ public class CompetingSentrySatisfactionTest {
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.testExitCriteriaWithOrSentry.cmmn",
-      "org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.oneTaskProcess.bpmn20.xml"})
+    "org/operaton/bpm/engine/test/concurrency/CompetingSentrySatisfactionTest.oneTaskProcess.bpmn20.xml"})
   @Test
-  public void testExitCriteriaWithOrSentry() {
+  void testExitCriteriaWithOrSentry() {
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")
         .create()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSignalsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSignalsTest.java
@@ -25,33 +25,32 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 
 /**
  * @author Tom Baeyens
  */
-public class CompetingSignalsTest {
+class CompetingSignalsTest {
 
   protected static Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected RuntimeService runtimeService;
   protected static ControllableThread activeThread;
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     runtimeService = engineRule.getRuntimeService();
   }
 
@@ -90,7 +89,7 @@ public class CompetingSignalsTest {
 
   @Deployment
   @Test
-  public void testCompetingSignals() {
+  void testCompetingSignals() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("CompetingSignalsProcess");
     String processInstanceId = processInstance.getId();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSubprocessCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSubprocessCompletionTest.java
@@ -28,27 +28,27 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cmd.CompleteTaskCmd;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 
 /**
  * @author Tom Baeyens
  */
-public class CompetingSubprocessCompletionTest {
+class CompetingSubprocessCompletionTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
@@ -57,8 +57,8 @@ public class CompetingSubprocessCompletionTest {
   static ControllableThread activeThread;
 
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
@@ -97,7 +97,7 @@ public class CompetingSubprocessCompletionTest {
    */
   @Deployment
   @Test
-  public void testCompetingSubprocessEnd() {
+  void testCompetingSubprocessEnd() {
     runtimeService.startProcessInstanceByKey("CompetingSubprocessEndProcess");
 
     List<Task> tasks = taskService.createTaskQuery().list();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
@@ -30,26 +30,25 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Thorben Lindhauer
  */
-public class CompetingSuspensionTest {
+class CompetingSuspensionTest {
 
   protected static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RepositoryService repositoryService;
@@ -58,8 +57,8 @@ public class CompetingSuspensionTest {
   protected static ControllableThread activeThread;
 
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     repositoryService = engineRule.getRepositoryService();
     runtimeService = engineRule.getRuntimeService();
@@ -138,7 +137,7 @@ public class CompetingSuspensionTest {
    */
   @Deployment
   @Test
-  public void testCompetingSuspension() {
+  void testCompetingSuspension() {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("CompetingSuspensionProcess").singleResult();
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingTransactionsOptimisticLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingTransactionsOptimisticLockingTest.java
@@ -16,29 +16,28 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CompetingTransactionsOptimisticLockingTest extends AbstractCompetingTransactionsOptimisticLockingTest {
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+class CompetingTransactionsOptimisticLockingTest extends AbstractCompetingTransactionsOptimisticLockingTest {
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = new ProcessEngineExtension();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
   }
 
   @Override
-  protected ProcessEngineTestRule getTestRule() {
+  protected ProcessEngineTestExtension getTestRule() {
     return testRule;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingTransactionsOptimisticLockingTestWithoutBatchProcessing.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingTransactionsOptimisticLockingTestWithoutBatchProcessing.java
@@ -16,34 +16,31 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class CompetingTransactionsOptimisticLockingTestWithoutBatchProcessing extends AbstractCompetingTransactionsOptimisticLockingTest {
 
-  @ClassRule
-  public static ProcessEngineBootstrapRule bootstrapRule = new ProcessEngineBootstrapRule(
-      "org/operaton/bpm/engine/test/concurrency/custombatchprocessing.operaton.cfg.xml");
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule(bootstrapRule);
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+class CompetingTransactionsOptimisticLockingTestWithoutBatchProcessing extends AbstractCompetingTransactionsOptimisticLockingTest {
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
+      .configurationResource("org/operaton/bpm/engine/test/concurrency/custombatchprocessing.operaton.cfg.xml")
+      .build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
   }
 
   @Override
-  protected ProcessEngineTestRule getTestRule() {
+  protected ProcessEngineTestExtension getTestRule() {
     return testRule;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingVariableFetchingAndDeletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingVariableFetchingAndDeletionTest.java
@@ -29,7 +29,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test makes sure that if one thread loads a variable
@@ -67,17 +67,17 @@ import org.junit.Test;
  * |         |                 (this must not perform
  * |         v                 update to VarInst)
  * v  time
-
+ 
  *
  * @author Daniel Meyer
  *
  */
-public class CompetingVariableFetchingAndDeletionTest extends ConcurrencyTestCase {
+class CompetingVariableFetchingAndDeletionTest extends ConcurrencyTestCase {
 
   private ThreadControl asyncThread;
 
   @Test
-  public void testConcurrentFetchAndDelete() {
+  void testConcurrentFetchAndDelete() {
 
    testRule.deploy(createExecutableProcess("test")
         .startEvent()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestCase.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestCase.java
@@ -23,11 +23,10 @@ import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Daniel Meyer
@@ -35,11 +34,10 @@ import org.junit.rules.RuleChain;
  */
 public abstract class ConcurrencyTestCase extends ConcurrencyTestHelper {
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  protected static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  protected ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected ProcessEngine processEngine;
   protected RepositoryService repositoryService;
@@ -48,20 +46,5 @@ public abstract class ConcurrencyTestCase extends ConcurrencyTestHelper {
   protected HistoryService historyService;
   protected ManagementService managementService;
   protected ExternalTaskService externalTaskService;
-
-  @Before
-  @Override
-  public void init() {
-    processEngine = engineRule.getProcessEngine();
-    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
-    repositoryService = engineRule.getRepositoryService();
-    runtimeService = engineRule.getRuntimeService();
-    taskService = engineRule.getTaskService();
-    historyService = engineRule.getHistoryService();
-    historyService = engineRule.getHistoryService();
-    managementService = engineRule.getManagementService();
-    externalTaskService = engineRule.getExternalTaskService();
-    super.init();
-  }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrencyTestHelper.java
@@ -23,20 +23,20 @@ import java.util.List;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.util.ExceptionUtil;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class ConcurrencyTestHelper {
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected List<ControllableCommand<?>> controllableCommands;
 
-  @Before
+  @BeforeEach
   public void init() {
     controllableCommands = new ArrayList<>();
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws Exception {
 
     // wait for all spawned threads to end

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
@@ -32,8 +32,8 @@ import org.operaton.bpm.engine.repository.DeploymentQuery;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>Tests the deployment from two threads simultaneously.</p>
@@ -44,7 +44,7 @@ import org.junit.Test;
  * @author Daniel Meyer
  */
 @RequiredDatabase(excludes = DbSqlSessionFactory.H2)
-public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
+class ConcurrentDeploymentTest extends ConcurrencyTestCase {
 
   private static String processResource;
 
@@ -62,7 +62,7 @@ public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
    * @see <a href="https://app.camunda.com/jira/browse/CAM-2128">https://app.camunda.com/jira/browse/CAM-2128</a>
    */
   @Test
-  public void testDuplicateFiltering() throws InterruptedException {
+  void testDuplicateFiltering() throws InterruptedException {
 
     deployOnTwoConcurrentThreads(
         createDeploymentBuilder().enableDuplicateFiltering(false),
@@ -75,7 +75,7 @@ public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
   }
 
   @Test
-  public void testVersioning() throws InterruptedException {
+  void testVersioning() throws InterruptedException {
 
     deployOnTwoConcurrentThreads(
         createDeploymentBuilder(),
@@ -137,8 +137,8 @@ public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
     thread2.waitUntilDone();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
 
     for(Deployment deployment : repositoryService.createDeploymentQuery().list()) {
       repositoryService.deleteDeployment(deployment.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentHistoryCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentHistoryCleanupTest.java
@@ -30,8 +30,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.test.util.DatabaseHelper;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>Tests the call to history cleanup simultaneously.</p>
@@ -41,10 +41,10 @@ import org.junit.Test;
  *
  * @author Svetlana Dorokhova
  */
-public class ConcurrentHistoryCleanupTest extends ConcurrencyTestCase {
+class ConcurrentHistoryCleanupTest extends ConcurrencyTestCase {
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     processEngineConfiguration.getCommandExecutorTxRequired().execute((Command<Void>) commandContext -> {
 
       List<Job> jobs = processEngine.getManagementService().createJobQuery().list();
@@ -60,8 +60,8 @@ public class ConcurrentHistoryCleanupTest extends ConcurrencyTestCase {
   }
 
   @Test
-  @RequiredDatabase(excludes = { DbSqlSessionFactory.MARIADB, DbSqlSessionFactory.H2 })
-  public void testRunTwoHistoryCleanups() throws InterruptedException {
+  @RequiredDatabase(excludes = {DbSqlSessionFactory.MARIADB, DbSqlSessionFactory.H2})
+  void testRunTwoHistoryCleanups() throws InterruptedException {
     final Integer transactionIsolationLevel = DatabaseHelper.getTransactionIsolationLevel(processEngineConfiguration);
     assumeTrue((transactionIsolationLevel != null && !transactionIsolationLevel.equals(Connection.TRANSACTION_READ_COMMITTED)));
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentHistoryLevelTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentHistoryLevelTest.java
@@ -28,8 +28,8 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.impl.test.TestHelper;
 import org.operaton.bpm.engine.test.util.DatabaseHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>Tests cluster scenario with two nodes trying to write the history level property in parallel.</p>
@@ -38,16 +38,16 @@ import org.junit.Test;
  * exclusive lock on table.</p>
  *
  */
-public class ConcurrentHistoryLevelTest extends ConcurrencyTestCase {
+class ConcurrentHistoryLevelTest extends ConcurrencyTestCase {
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     TestHelper.deleteHistoryLevel(processEngineConfiguration);
   }
 
   @Test
-  @RequiredDatabase(excludes = { DbSqlSessionFactory.H2, DbSqlSessionFactory.MARIADB })
-  public void test() throws InterruptedException {
+  @RequiredDatabase(excludes = {DbSqlSessionFactory.H2, DbSqlSessionFactory.MARIADB})
+  void test() throws InterruptedException {
     Integer transactionIsolationLevel = DatabaseHelper.getTransactionIsolationLevel(processEngineConfiguration);
     assumeThat((transactionIsolationLevel != null && !transactionIsolationLevel.equals(Connection.TRANSACTION_READ_COMMITTED)));
     ThreadControl thread1 = executeControllableCommand(new ControllableUpdateHistoryLevelCommand());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
@@ -27,8 +27,8 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.impl.test.TestHelper;
 import org.operaton.bpm.engine.test.util.DatabaseHelper;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>Tests cluster scenario with two nodes trying to write the installation id property in parallel.</p>
@@ -37,16 +37,16 @@ import org.junit.Test;
  * exclusive lock on table.</p>
  *
  */
-public class ConcurrentInstallationIdInitializationTest extends ConcurrencyTestCase {
+class ConcurrentInstallationIdInitializationTest extends ConcurrencyTestCase {
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     TestHelper.deleteInstallationId(processEngineConfiguration);
   }
 
   @Test
   @RequiredDatabase(excludes = {DbSqlSessionFactory.H2, DbSqlSessionFactory.MARIADB})
-  public void test() throws InterruptedException {
+  void test() throws InterruptedException {
     Integer transactionIsolationLevel = DatabaseHelper.getTransactionIsolationLevel(processEngineConfiguration);
     assumeThat((transactionIsolationLevel != null && !transactionIsolationLevel.equals(Connection.TRANSACTION_READ_COMMITTED)));
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
@@ -45,30 +45,29 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Thorben Lindhauer
  *
  */
-public class ConcurrentJobExecutorTest {
+class ConcurrentJobExecutorTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
   protected RuntimeService runtimeService;
   protected RepositoryService repositoryService;
@@ -85,16 +84,16 @@ public class ConcurrentJobExecutorTest {
       .endEvent()
       .done();
 
-  @Before
-  public void initServices() {
+  @BeforeEach
+  void initServices() {
     runtimeService = engineRule.getRuntimeService();
     repositoryService = engineRule.getRepositoryService();
     managementService = engineRule.getManagementService();
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     ClockUtil.reset();
     for(final Job job : managementService.createJobQuery().list()) {
 
@@ -106,7 +105,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompetingJobExecutionDeleteJobDuringExecution() {
+  void testCompetingJobExecutionDeleteJobDuringExecution() {
     //given a simple process with a async service task
     testRule.deploy(Bpmn
             .createExecutableProcess("process")
@@ -132,7 +131,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void shouldCompleteTimeoutRetryWhenTimeoutedJobCompletesInbetween() {
+  void shouldCompleteTimeoutRetryWhenTimeoutedJobCompletesInbetween() {
     // given a simple process with an async service task
     testRule.deploy(Bpmn
         .createExecutableProcess("process")
@@ -178,7 +177,7 @@ public class ConcurrentJobExecutorTest {
 
   @Test
   @Deployment
-  public void testCompetingJobExecutionDefaultRetryStrategy() {
+  void testCompetingJobExecutionDefaultRetryStrategy() {
     // given an MI subprocess with two instances
     runtimeService.startProcessInstanceByKey("miParallelSubprocess");
 
@@ -217,7 +216,7 @@ public class ConcurrentJobExecutorTest {
 
   @Test
   @Deployment
-  public void testCompetingJobExecutionFoxRetryStrategy() {
+  void testCompetingJobExecutionFoxRetryStrategy() {
     // given an MI subprocess with two instances
     runtimeService.startProcessInstanceByKey("miParallelSubprocess");
 
@@ -256,7 +255,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompletingJobExecutionSuspendDuringExecution() {
+  void testCompletingJobExecutionSuspendDuringExecution() {
     testRule.deploy(SIMPLE_ASYNC_PROCESS);
 
     runtimeService.startProcessInstanceByKey("simpleAsyncProcess");
@@ -296,7 +295,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompletingSuspendJobDuringAcquisition() {
+  void testCompletingSuspendJobDuringAcquisition() {
     testRule.deploy(SIMPLE_ASYNC_PROCESS);
 
     runtimeService.startProcessInstanceByKey("simpleAsyncProcess");
@@ -338,7 +337,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompletingSuspendedJobDuringRunningInstance() {
+  void testCompletingSuspendedJobDuringRunningInstance() {
     testRule.deploy(Bpmn.createExecutableProcess("process")
         .startEvent()
         .receiveTask()
@@ -373,7 +372,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompletingUpdateJobDefinitionPriorityDuringExecution() {
+  void testCompletingUpdateJobDefinitionPriorityDuringExecution() {
     testRule.deploy(SIMPLE_ASYNC_PROCESS);
 
     // given
@@ -415,7 +414,7 @@ public class ConcurrentJobExecutorTest {
   }
 
   @Test
-  public void testCompletingSuspensionJobDuringPriorityUpdate() {
+  void testCompletingSuspensionJobDuringPriorityUpdate() {
     testRule.deploy(SIMPLE_ASYNC_PROCESS);
 
     // given

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest.java
@@ -35,9 +35,9 @@ import org.operaton.bpm.engine.impl.interceptor.CommandInvocationContext;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.runtime.Job;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * <p>Tests a concurrent attempt of a bootstrapping Process Engine to reconfigure
@@ -62,12 +62,12 @@ import org.junit.Test;
  *
  * @author Nikola Koevski
  */
-public class ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest extends ConcurrencyTestCase {
+class ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest extends ConcurrencyTestCase {
 
   private static final String PROCESS_ENGINE_NAME = "historyCleanupJobEngine";
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
 
     // Ensure that current time is outside batch window
     Calendar timeOfDay = Calendar.getInstance();
@@ -101,8 +101,8 @@ public class ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest extends Con
     }
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     processEngineConfiguration.getCommandExecutorTxRequired().execute((Command<Void>) commandContext -> {
 
       List<Job> jobs = processEngine.getManagementService().createJobQuery().list();
@@ -120,7 +120,7 @@ public class ConcurrentProcessEngineJobExecutorHistoryCleanupJobTest extends Con
   }
 
   @Test
-  public void testConcurrentHistoryCleanupJobReconfigurationExecution() throws InterruptedException {
+  void testConcurrentHistoryCleanupJobReconfigurationExecution() throws InterruptedException {
 
     processEngine.getHistoryService().cleanUpHistoryAsync(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.java
@@ -29,27 +29,27 @@ import org.operaton.bpm.engine.impl.cmd.SetTaskVariablesCmd;
 import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Test;
+
 import org.slf4j.Logger;
 
 /**
  * @author Daniel Meyer
  *
  */
-public class ConcurrentVariableUpdateTest {
+class ConcurrentVariableUpdateTest {
 
   private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
-  protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
+  @RegisterExtension
+  static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RuntimeService runtimeService;
@@ -58,8 +58,8 @@ public class ConcurrentVariableUpdateTest {
   protected static ControllableThread activeThread;
 
 
-  @Before
-  public void initializeServices() {
+  @BeforeEach
+  void initializeServices() {
     processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
@@ -104,10 +104,10 @@ public class ConcurrentVariableUpdateTest {
 
   // Test is skipped when testing on DB2.
   // Please update the IF condition in #runTest, if the method name is changed.
-  @Deployment(resources="org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
   @Test
   @RequiredDatabase(excludes = DbSqlSessionFactory.DB2)
-  public void testConcurrentVariableCreate() {
+  void testConcurrentVariableCreate() {
 
     runtimeService.startProcessInstanceByKey("testProcess", Collections.<String, Object>singletonMap("varName1", "someValue"));
 
@@ -133,9 +133,9 @@ public class ConcurrentVariableUpdateTest {
     taskService.complete(taskId);
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
   @Test
-  public void testConcurrentVariableUpdate() {
+  void testConcurrentVariableUpdate() {
 
     runtimeService.startProcessInstanceByKey("testProcess");
 
@@ -162,9 +162,9 @@ public class ConcurrentVariableUpdateTest {
   }
 
 
-  @Deployment(resources="org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/ConcurrentVariableUpdateTest.process.bpmn20.xml")
   @Test
-  public void testConcurrentVariableUpdateTypeChange() {
+  void testConcurrentVariableUpdateTypeChange() {
 
     runtimeService.startProcessInstanceByKey("testProcess");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/DeleteProcessDefinitionTest.java
@@ -20,23 +20,23 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.EventSubscription;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
+class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     repositoryService.createDeploymentQuery().list().forEach(deployment -> repositoryService.deleteDeployment(deployment.getId(), true));
     processEngineConfiguration.getDeploymentCache().purgeCache();
   }
 
   @Test
-  public void testDeploymentOfProcessDefinitionWithOrphanMessageEvent() {
+  void testDeploymentOfProcessDefinitionWithOrphanMessageEvent() {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithNewInvoiceMessage.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
@@ -55,7 +55,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
   }
 
   @Test
-  public void testDeploymentOfProcessDefinitionWithOrphanJob() {
+  void testDeploymentOfProcessDefinitionWithOrphanJob() {
     // given
     String resource = "org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.testTimeCycle.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
@@ -74,7 +74,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
   }
 
   @Test
-  public void testDeploymentOfProcessDefinitionWithOrphanSignalEvent() {
+  void testDeploymentOfProcessDefinitionWithOrphanSignalEvent() {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithStartSignalEvent.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
@@ -93,7 +93,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
   }
 
   @Test
-  public void testDeploymentOfProcessDefinitionWithOrphanEventAndPreviousVersion() {
+  void testDeploymentOfProcessDefinitionWithOrphanEventAndPreviousVersion() {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithNewInvoiceMessage.bpmn20.xml";
     repositoryService.createDeployment().addClasspathResource(resource).deploy();
@@ -116,7 +116,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
   }
 
   @Test
-  public void testDeploymentOfProcessDefinitionWithOrphanConditionalEvent() {
+  void testDeploymentOfProcessDefinitionWithOrphanConditionalEvent() {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithConditionalStartEvent.bpmn20.xml";
     List<ProcessDefinition> definitions = deployProcessDefinitionTwice(resource);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ThrowOleWhenDeletingExceptionStacktraceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ThrowOleWhenDeletingExceptionStacktraceTest.java
@@ -24,18 +24,18 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tassilo Weidner
  */
-public class ThrowOleWhenDeletingExceptionStacktraceTest extends ConcurrencyTestCase {
+class ThrowOleWhenDeletingExceptionStacktraceTest extends ConcurrencyTestCase {
 
   protected AtomicReference<JobEntity> job = new AtomicReference<>();
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     if (job.get() != null) {
       processEngineConfiguration.getCommandExecutorTxRequired().execute((Command<Void>) commandContext -> {
         JobEntity jobEntity = job.get();
@@ -52,7 +52,7 @@ public class ThrowOleWhenDeletingExceptionStacktraceTest extends ConcurrencyTest
   }
 
   @Test
-  public void testThrowOleWhenDeletingExceptionStacktraceTest() {
+  void testThrowOleWhenDeletingExceptionStacktraceTest() {
     // given
     processEngineConfiguration.getCommandExecutorTxRequired()
       .execute((Command<Void>) commandContext -> {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/TransactionIsolationReadCommittedTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/TransactionIsolationReadCommittedTest.java
@@ -28,15 +28,15 @@ import org.operaton.bpm.engine.impl.history.event.HistoricProcessInstanceEventEn
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-public class TransactionIsolationReadCommittedTest extends ConcurrencyTestCase {
+class TransactionIsolationReadCommittedTest extends ConcurrencyTestCase {
 
   private ThreadControl thread1;
   private ThreadControl thread2;
@@ -61,7 +61,7 @@ public class TransactionIsolationReadCommittedTest extends ConcurrencyTestCase {
    *
    */
   @Test
-  public void testTransactionIsolation() {
+  void testTransactionIsolation() {
 
     thread1 = executeControllableCommand(new TestCommand("p1"));
 
@@ -119,8 +119,8 @@ public class TransactionIsolationReadCommittedTest extends ConcurrencyTestCase {
 
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
 
     // end interaction with Thread 2
     thread2.waitUntilDone();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/UuidGeneratorTest.java
@@ -25,19 +25,19 @@ import com.fasterxml.uuid.EthernetAddress;
 import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedGenerator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Daniel Meyer
  *
  */
-public class UuidGeneratorTest {
+class UuidGeneratorTest {
 
   private static final int THREAD_COUNT = 10;
   private static final int LOOP_COUNT = 10000;
 
   @Test
-  public void testMultithreaded() throws InterruptedException {
+  void testMultithreaded() throws InterruptedException {
     final List<Thread> threads = new ArrayList<>();
 
     final TimeBasedGenerator timeBasedGenerator = Generators.timeBasedGenerator(EthernetAddress.fromInterface());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/AbstractPartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/AbstractPartitioningTest.java
@@ -25,7 +25,7 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.concurrency.ConcurrencyTestCase;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Tassilo Weidner
@@ -36,7 +36,7 @@ public abstract class AbstractPartitioningTest extends ConcurrencyTestCase {
 
   protected CommandExecutor commandExecutor;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     processEngine.getProcessEngineConfiguration().setSkipHistoryOptimisticLockingExceptions(true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricAttachmentPartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricAttachmentPartitioningTest.java
@@ -22,16 +22,16 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.AttachmentEntity;
 import org.operaton.bpm.engine.task.Attachment;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tassilo Weidner
  */
 
-public class CompetingHistoricAttachmentPartitioningTest extends AbstractPartitioningTest {
+class CompetingHistoricAttachmentPartitioningTest extends AbstractPartitioningTest {
 
   @Test
-  public void shouldSuppressOleOnConcurrentFetchAndDelete() {
+  void shouldSuppressOleOnConcurrentFetchAndDelete() {
     // given
     String processInstanceId = deployAndStartProcess(PROCESS_WITH_USERTASK).getId();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricByteArrayPartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricByteArrayPartitioningTest.java
@@ -25,20 +25,20 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tassilo Weidner
  */
 
-public class CompetingHistoricByteArrayPartitioningTest extends AbstractPartitioningTest {
+class CompetingHistoricByteArrayPartitioningTest extends AbstractPartitioningTest {
 
   static final String VARIABLE_NAME = "aVariableName";
   static final String VARIABLE_VALUE = "aVariableValue";
   static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
-  public void shouldSuppressOleOnConcurrentFetchAndDelete() {
+  void shouldSuppressOleOnConcurrentFetchAndDelete() {
     // given
     final String processInstanceId = deployAndStartProcess(PROCESS_WITH_USERTASK,
       Variables.createVariables().putValue(VARIABLE_NAME,

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricVariableInstancePartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricVariableInstancePartitioningTest.java
@@ -22,20 +22,20 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tassilo Weidner
  */
 
-public class CompetingHistoricVariableInstancePartitioningTest extends AbstractPartitioningTest {
+class CompetingHistoricVariableInstancePartitioningTest extends AbstractPartitioningTest {
 
   static final String VARIABLE_NAME = "aVariableName";
   static final String VARIABLE_VALUE = "aVariableValue";
   static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
-  public void shouldSuppressOleOnConcurrentFetchAndDelete() {
+  void shouldSuppressOleOnConcurrentFetchAndDelete() {
     // given
     String processInstanceId = deployAndStartProcess(PROCESS_WITH_USERTASK,
       Variables.createVariables().putValue(VARIABLE_NAME, VARIABLE_VALUE)).getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
@@ -22,20 +22,20 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Tassilo Weidner
  */
 
-public class SkipHistoryOptimisticLockingExceptionsDisabledTest extends AbstractPartitioningTest {
+class SkipHistoryOptimisticLockingExceptionsDisabledTest extends AbstractPartitioningTest {
 
   static final String VARIABLE_NAME = "aVariableName";
   static final String VARIABLE_VALUE = "aVariableValue";
   static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
-  public void testHistoryOptimisticLockingExceptionsNotSkipped() {
+  void testHistoryOptimisticLockingExceptionsNotSkipped() {
     // given
     processEngine.getProcessEngineConfiguration().setSkipHistoryOptimisticLockingExceptions(false);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseFlushTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseFlushTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DatabaseFlushTest extends ConcurrencyTestCase {
 
@@ -63,7 +63,7 @@ public class DatabaseFlushTest extends ConcurrencyTestCase {
    */
   @RequiredDatabase(excludes = DbSqlSessionFactory.DB2)
   @Test
-  public void testNoIncompleteFlushOnConstraintViolation()
+  void testNoIncompleteFlushOnConstraintViolation()
   {
     // given
    testRule.deploy(GW_PROCESS);


### PR DESCRIPTION
## Summary
- switch concurrency infrastructure classes to JUnit 5 lifecycle callbacks
- update all concurrency test classes to use `ProcessEngineExtension`
- adapt partitioning and persistence tests to new extensions

## Testing
- `./mvnw -q -pl engine -DskipITs -DskipITests test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb199b274832dabc6eeb232a67013